### PR TITLE
Chore/post publish cleanup

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ build:
     - asdf install uv latest
     - asdf global uv latest
     - uv sync --frozen
-    - uv run mkdocs build
+    - uv run mkdocs build --site-dir $READTHEDOCS_OUTPUT/html
 
 # Build documentation with Mkdocs
 mkdocs:

--- a/README.md
+++ b/README.md
@@ -18,11 +18,6 @@ A simple Python package to make using [CronMon](https://github.com/cron-mon-io) 
 pip install cron-mon-py
 ```
 
-> `cron-mon-py` isn't currently published anywhere, so this doesn't work just yet. You can however, install from Git
-> ```console
-> pip install git+https://github.com/cron-mon-io/cron-mon-py.git
-> ```
-
 ## Example
 
 Simply import the `monitor` decorator and use it on any function that serves as the entry point to your cron job/ scheduled task that you wish to monitor:


### PR DESCRIPTION
Bit of a cleanup post package publish - remove a now irrelevant note in the README and ensure that the RTD docs are built successfully.